### PR TITLE
Use go:embed for embedding binary data

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,8 +753,9 @@ package.
 
 ## Embed binary data
 
-To enable single-binary deployments, use tools to add templates and other static
-assets to your binary
+To enable single-binary deployments, use the `//go:embed` directive and the [embed](https://pkg.go.dev/embed) package to add templates and other static
+assets to your binary.  
+For Go versions prior [v1.16](https://go.dev/doc/go1.16#library-embed), use external tools 
 (e.g. [github.com/gobuffalo/packr](https://github.com/gobuffalo/packr)).
 
 ## Use `io.WriteString`


### PR DESCRIPTION
The [embed](https://pkg.go.dev/embed) package was added in [Go v1.16](https://go.dev/doc/go1.16#library-embed). It should be the preferred way to embed binary data into Go binaries.